### PR TITLE
[Java API] Add Infer method

### DIFF
--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/Neuropod.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/Neuropod.java
@@ -75,7 +75,7 @@ public class Neuropod extends NativeClass {
      * @return the inference result
      */
     public Map<String, NeuropodTensor> infer(Map<String, NeuropodTensor> inputs) {
-        return null;
+        return infer(inputs, null);
     }
 
     /**
@@ -87,7 +87,7 @@ public class Neuropod extends NativeClass {
      * @return the inference result
      */
     public Map<String, NeuropodTensor> infer(Map<String, NeuropodTensor> inputs, List<String> requestedOutputs) {
-        return null;
+        return nativeInfer(inputs.entrySet().toArray(), requestedOutputs, super.getNativeHandle());
     }
 
     /**
@@ -148,6 +148,9 @@ public class Neuropod extends NativeClass {
     private static native long nativeGetAllocator(long modelHandle);
 
     private static native long nativeGetGenericAllocator();
+
+    private static native Map<String, NeuropodTensor> nativeInfer(Object[] inputs, List<String> requestedOutputs,
+                                                                  long modelHandle);
 
     @Override
     protected native void nativeDelete(long handle);

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_Neuropod.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_Neuropod.cc
@@ -215,3 +215,64 @@ JNIEXPORT jlong JNICALL Java_com_uber_neuropod_Neuropod_nativeGetGenericAllocato
     }
     return reinterpret_cast<jlong>(nullptr);
 }
+
+JNIEXPORT jobject JNICALL Java_com_uber_neuropod_Neuropod_nativeInfer(
+    JNIEnv *env, jclass, jobjectArray entryArray, jobject requestedOutputsJava, jlong modelHandle)
+{
+    try
+    {
+
+        // Prepare requestedOutputs
+        std::vector<std::string> requestedOutputs;
+        if (requestedOutputsJava != nullptr)
+        {
+            jsize size = env->CallIntMethod(requestedOutputsJava, java_util_ArrayList_size);
+            for (jsize i = 0; i < size; i++)
+            {
+                jstring element =
+                    static_cast<jstring>(env->CallObjectMethod(requestedOutputsJava, java_util_ArrayList_get, i));
+                requestedOutputs.emplace_back(toString(env, element));
+                env->DeleteLocalRef(element);
+            }
+        }
+
+        // Fill in NeuropodValueMap
+        jsize                      entrySize = env->GetArrayLength(entryArray);
+        neuropod::NeuropodValueMap nativeMap;
+        for (jsize i = 0; i < entrySize; i++)
+        {
+            jobject     entry = env->GetObjectArrayElement(entryArray, i);
+            std::string key =
+                toString(env, static_cast<jstring>(env->CallObjectMethod(entry, java_util_Map_Entry_getKey)));
+            jobject value        = env->CallObjectMethod(entry, java_util_Map_Entry_getValue);
+            jlong   tensorHandle = env->CallLongMethod(value, com_uber_neuropod_NeuropodTensor_getHandle);
+            if (tensorHandle == 0)
+            {
+                throw std::runtime_error("Deallocated Object!");
+            }
+            nativeMap[key] = (*reinterpret_cast<std::shared_ptr<neuropod::NeuropodValue> *>(tensorHandle));
+            env->DeleteLocalRef(entry);
+            env->DeleteLocalRef(value);
+        }
+
+        auto model       = reinterpret_cast<neuropod::Neuropod *>(modelHandle);
+        auto inferredMap = model->infer(nativeMap, requestedOutputs);
+
+        // Put data to Java Map
+        auto ret = env->NewObject(java_util_HashMap, java_util_HashMap_);
+        for (auto &entry : *inferredMap)
+        {
+            jobject javaTensor = env->NewObject(com_uber_neuropod_NeuropodTensor,
+                                                com_uber_neuropod_NeuropodTensor_,
+                                                reinterpret_cast<jlong>(toHeap((entry.second))));
+            env->CallObjectMethod(ret, java_util_HashMap_put, env->NewStringUTF(entry.first.c_str()), javaTensor);
+            env->DeleteLocalRef(javaTensor);
+        }
+        return ret;
+    }
+    catch (const std::exception &e)
+    {
+        throwJavaException(env, e.what());
+    }
+    return nullptr;
+}

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_Neuropod.h
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_Neuropod.h
@@ -83,6 +83,13 @@ JNIEXPORT jlong JNICALL Java_com_uber_neuropod_Neuropod_nativeGetGenericAllocato
 
 /*
  * Class:     com_uber_neuropod_Neuropod
+ * Method:    nativeInfer
+ * Signature: ([Ljava/lang/Object;Ljava/util/List;J)Ljava/util/Map;
+ */
+JNIEXPORT jobject JNICALL Java_com_uber_neuropod_Neuropod_nativeInfer(JNIEnv *, jclass, jobjectArray, jobject, jlong);
+
+/*
+ * Class:     com_uber_neuropod_Neuropod
  * Method:    nativeDelete
  * Signature: (J)V
  */

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
@@ -26,6 +26,38 @@ JNIEXPORT void JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeDoDelete(JNIE
     }
 }
 
+JNIEXPORT jobject JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetBuffer(JNIEnv *env, jclass, jlong nativeHandle)
+{
+    try
+    {
+        auto neuropodTensor =
+            (*reinterpret_cast<std::shared_ptr<neuropod::NeuropodValue> *>(nativeHandle))->as_tensor();
+        auto tensorType = neuropodTensor->get_tensor_type();
+        switch (tensorType)
+        {
+        case neuropod::FLOAT_TENSOR: {
+            return createDirectBuffer<float>(env, neuropodTensor);
+        }
+        case neuropod::DOUBLE_TENSOR: {
+            return createDirectBuffer<double>(env, neuropodTensor);
+        }
+        case neuropod::INT32_TENSOR: {
+            return createDirectBuffer<int32_t>(env, neuropodTensor);
+        }
+        case neuropod::INT64_TENSOR: {
+            return createDirectBuffer<int64_t>(env, neuropodTensor);
+        }
+        default:
+            throw std::runtime_error(std::string("Unsupported tensor type: ") + tensorTypeToString(tensorType));
+        }
+    }
+    catch (const std::exception &e)
+    {
+        throwJavaException(env, e.what());
+    }
+    return nullptr;
+}
+
 JNIEXPORT jlongArray JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetDims(JNIEnv *env, jclass, jlong handle)
 {
     try

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.h
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.h
@@ -31,6 +31,13 @@ JNIEXPORT void JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeDoDelete(JNIE
 
 /*
  * Class:     com_uber_neuropod_NeuropodTensor
+ * Method:    nativeGetBuffer
+ * Signature: (J)Ljava/nio/ByteBuffer;
+ */
+JNIEXPORT jobject JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetBuffer(JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_uber_neuropod_NeuropodTensor
  * Method:    nativeGetDims
  * Signature: (J)[J
  */

--- a/source/neuropod/bindings/java/src/main/native/jclass_register.cc
+++ b/source/neuropod/bindings/java/src/main/native/jclass_register.cc
@@ -31,6 +31,14 @@ jmethodID java_util_ArrayList_add;
 jmethodID java_util_ArrayList_get;
 jmethodID java_util_ArrayList_size;
 
+jclass    java_util_HashMap;
+jmethodID java_util_HashMap_;
+jmethodID java_util_HashMap_put;
+
+jclass    java_util_Map_Entry;
+jmethodID java_util_Map_Entry_getKey;
+jmethodID java_util_Map_Entry_getValue;
+
 jclass    com_uber_neuropod_TensorSpec;
 jmethodID com_uber_neuropod_TensorSpec_;
 
@@ -39,6 +47,10 @@ jmethodID com_uber_neuropod_Dimension_value_;
 jmethodID com_uber_neuropod_Dimension_symbol_;
 
 jclass com_uber_neuropod_TensorType;
+
+jclass    com_uber_neuropod_NeuropodTensor;
+jmethodID com_uber_neuropod_NeuropodTensor_;
+jmethodID com_uber_neuropod_NeuropodTensor_getHandle;
 
 jclass com_uber_neuropod_NeuropodJNIException;
 
@@ -72,6 +84,15 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
         java_util_ArrayList_get  = getMethodID(env, java_util_ArrayList, "get", "(I)Ljava/lang/Object;");
         java_util_ArrayList_size = getMethodID(env, java_util_ArrayList, "size", "()I");
 
+        java_util_HashMap  = static_cast<jclass>(env->NewGlobalRef(findClass(env, "java/util/HashMap")));
+        java_util_HashMap_ = getMethodID(env, java_util_HashMap, "<init>", "()V");
+        java_util_HashMap_put =
+            getMethodID(env, java_util_HashMap, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+
+        java_util_Map_Entry          = static_cast<jclass>(env->NewGlobalRef(findClass(env, "java/util/Map$Entry")));
+        java_util_Map_Entry_getKey   = getMethodID(env, java_util_Map_Entry, "getKey", "()Ljava/lang/Object;");
+        java_util_Map_Entry_getValue = getMethodID(env, java_util_Map_Entry, "getValue", "()Ljava/lang/Object;");
+
         com_uber_neuropod_TensorSpec =
             static_cast<jclass>(env->NewGlobalRef(findClass(env, "com/uber/neuropod/TensorSpec")));
         com_uber_neuropod_TensorSpec_ =
@@ -88,6 +109,12 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
 
         com_uber_neuropod_TensorType =
             static_cast<jclass>(env->NewGlobalRef(findClass(env, "com/uber/neuropod/TensorType")));
+
+        com_uber_neuropod_NeuropodTensor =
+            static_cast<jclass>(env->NewGlobalRef(findClass(env, "com/uber/neuropod/NeuropodTensor")));
+        com_uber_neuropod_NeuropodTensor_ = getMethodID(env, com_uber_neuropod_NeuropodTensor, "<init>", "(J)V");
+        com_uber_neuropod_NeuropodTensor_getHandle =
+            getMethodID(env, com_uber_neuropod_NeuropodTensor, "getHandle", "()J");
     }
     catch (const std::exception &e)
     {
@@ -105,9 +132,12 @@ void JNI_OnUnload(JavaVM *vm, void *reserved)
     vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION);
     // Destroy the global references
     env->DeleteGlobalRef(java_util_ArrayList);
+    env->DeleteGlobalRef(java_util_HashMap);
+    env->DeleteGlobalRef(java_util_Map_Entry);
 
     env->DeleteGlobalRef(com_uber_neuropod_Dimension);
     env->DeleteGlobalRef(com_uber_neuropod_TensorSpec);
     env->DeleteGlobalRef(com_uber_neuropod_TensorType);
+    env->DeleteGlobalRef(com_uber_neuropod_NeuropodTensor);
     env->DeleteGlobalRef(com_uber_neuropod_NeuropodJNIException);
 }

--- a/source/neuropod/bindings/java/src/main/native/jclass_register.h
+++ b/source/neuropod/bindings/java/src/main/native/jclass_register.h
@@ -27,6 +27,16 @@ extern jmethodID java_util_ArrayList_add;
 extern jmethodID java_util_ArrayList_get;
 extern jmethodID java_util_ArrayList_size;
 
+extern jclass    java_util_HashMap;
+extern jmethodID java_util_HashMap_;
+extern jmethodID java_util_HashMap_put;
+
+extern jclass    java_util_Map_Entry;
+extern jmethodID java_util_Map_Entry_getKey;
+extern jmethodID java_util_Map_Entry_getValue;
+
+extern jclass com_uber_neuropod_TensorType;
+
 extern jclass    com_uber_neuropod_TensorSpec;
 extern jmethodID com_uber_neuropod_TensorSpec_;
 
@@ -34,7 +44,9 @@ extern jclass    com_uber_neuropod_Dimension;
 extern jmethodID com_uber_neuropod_Dimension_value_;
 extern jmethodID com_uber_neuropod_Dimension_symbol_;
 
-extern jclass com_uber_neuropod_TensorType;
+extern jclass    com_uber_neuropod_NeuropodTensor;
+extern jmethodID com_uber_neuropod_NeuropodTensor_;
+extern jmethodID com_uber_neuropod_NeuropodTensor_getHandle;
 
 extern jclass com_uber_neuropod_NeuropodJNIException;
 

--- a/source/neuropod/bindings/java/src/main/native/utils.cc
+++ b/source/neuropod/bindings/java/src/main/native/utils.cc
@@ -43,7 +43,7 @@ jclass findClass(JNIEnv *env, const char *name)
     jclass ret = env->FindClass(name);
     if (reinterpret_cast<jlong>(ret) == 0)
     {
-        throw std::runtime_error(std::string("Class not found: ") + name);
+        throw std::runtime_error(std::string("class not found: ") + name);
     }
     return ret;
 }
@@ -53,7 +53,7 @@ jmethodID getMethodID(JNIEnv *env, jclass clazz, const char *name, const char *s
     jmethodID ret = env->GetMethodID(clazz, name, sig);
     if (reinterpret_cast<jlong>(ret) == 0)
     {
-        throw std::runtime_error(std::string("Method ID not found: ") + name + sig);
+        throw std::runtime_error(std::string("method ID not found: ") + name + sig);
     }
     return ret;
 }
@@ -63,7 +63,7 @@ jobject getTensorTypeField(JNIEnv *env, std::string fieldName)
     jfieldID field = env->GetStaticFieldID(com_uber_neuropod_TensorType, fieldName.c_str(), TENSOR_TYPE.c_str());
     if (reinterpret_cast<jlong>(field) == 0)
     {
-        throw std::runtime_error(std::string("Field not found: ") + fieldName);
+        throw std::runtime_error(std::string("field not found: ") + fieldName);
     }
     return env->GetStaticObjectField(com_uber_neuropod_TensorType, field);
 }

--- a/source/neuropod/bindings/java/src/main/native/utils.h
+++ b/source/neuropod/bindings/java/src/main/native/utils.h
@@ -49,6 +49,10 @@ std::shared_ptr<T> *toHeap(std::shared_ptr<T> ptr)
     return new std::shared_ptr<T>(ptr);
 }
 
+// Create a direct buffer for the tensor data
+template <typename T>
+jobject createDirectBuffer(JNIEnv *env, NeuropodTensor *tensor);
+
 // Throw a Java NeuropodJNIException exception after the JNI call have finished.
 // If there are multiple throwJavaException calls during a C++ function, only the
 // last one is effective.
@@ -56,3 +60,4 @@ void throwJavaException(JNIEnv *env, const char *message);
 
 } // namespace jni
 } // namespace neuropod
+#include "utils_impl.h"

--- a/source/neuropod/bindings/java/src/main/native/utils_impl.h
+++ b/source/neuropod/bindings/java/src/main/native/utils_impl.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2020 UATC, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+namespace neuropod
+{
+namespace jni
+{
+
+template <typename T>
+jobject createDirectBuffer(JNIEnv *env, NeuropodTensor *tensor)
+{
+    auto         typedTensor = tensor->as_typed_tensor<T>();
+    auto         rawPtr      = typedTensor->get_raw_data_ptr();
+    const size_t memSize     = sizeof(T) * tensor->get_num_elements();
+    return env->NewDirectByteBuffer(rawPtr, static_cast<jlong>(memSize));
+}
+
+} // namespace jni
+} // namespace neuropod


### PR DESCRIPTION
Summary:
Implement the infer method.  The infer method will create tensors from the C++ side. The buffers of the Tensors created from the C++ side are wrappers for C++ memory. 

Test Plan:
bazel test //neuropod/bindings/java:*

